### PR TITLE
Add ability to sort Pokédex by first-owned and alphabetically

### DIFF
--- a/bin/tables.js
+++ b/bin/tables.js
@@ -113,6 +113,52 @@ function generateGlobalDex(tppData) {
             }).filter(function (c) { return c.Runs.length > 0; });
         }
     }
+    if ("Alphabetical" == QueryString["sort"]) {
+        PokeList.sort();
+    }
+    if ("First Owned" == QueryString["sort"]) {
+        dexSummarize(tppData).then(function (summaries) {
+            var firstTimes = {};
+            PokeList.forEach(function (p) { return firstTimes[p] = false; });
+            summaries.forEach(function (summary) {
+                if (summary.OwnedDict) {
+                    Object.keys(summary.OwnedDict).forEach(function (p) {
+                        var newTime = summary.OwnedDict[p];
+                        if (newTime) {
+                            if (firstTimes[p]) {
+                                if (firstTimes[p] > newTime) {
+                                    firstTimes[p] = newTime;
+                                }
+                            }
+                            else {
+                                firstTimes[p] = newTime;
+                            }
+                        }
+                    });
+                }
+            });
+            PokeList.sort(function (a, b) {
+                var a2 = firstTimes[a];
+                var b2 = firstTimes[b];
+                if (a2) {
+                    if (b2) {
+                        return a2 - b2;
+                    }
+                    else {
+                        return -1;
+                    }
+                }
+                else {
+                    if (b2) {
+                        return 1;
+                    }
+                    else {
+                        return 0;
+                    }
+                }
+            });
+        });
+    }
     dexSummarize(tppData).then(function (summaries) {
         summaries = summaries.sort(function (s1, s2) { return s1.Run.StartTime - s2.Run.StartTime; });
         var hofData = summaries.map(function (s) { return s.HallOfFame; }).reduce(function (a, b) { return a.concat(b); }).sort(function (h1, h2) { return h1.Time - h2.Time; });

--- a/display/controls.ts
+++ b/display/controls.ts
@@ -180,6 +180,8 @@ var pokedexGenerationsMenu = () => qsListMenu("fa-gamepad", "Generations", "g", 
 
 var pokedexRegionsMenu = () => qsListMenu("fa-globe", "Region", "dex", Object.keys(Pokedex.Regional).map((m, i) => i ? m : null), "National");
 
+var pokedexSortMenu = () => qsListMenu("fa-sort", "Sort", "sort", [null, "Alphabetical", "First Owned"], "Pokédex Number");
+
 var getTwitchVideos = getTwitchVideos || function () { };
 function twitchButton() {
     var button = document.createElement("li");

--- a/display/tpp-display.js
+++ b/display/tpp-display.js
@@ -364,6 +364,7 @@ function regionMenu(regionsParam) {
 }
 var pokedexGenerationsMenu = function () { return qsListMenu("fa-gamepad", "Generations", "g", Pokedex.GenSlice.map(function (g, i) { return i ? i.toFixed(0) : null; }), "All", "Generation "); };
 var pokedexRegionsMenu = function () { return qsListMenu("fa-globe", "Region", "dex", Object.keys(Pokedex.Regional).map(function (m, i) { return i ? m : null; }), "National"); };
+var pokedexSortMenu = function () { return qsListMenu("fa-sort", "Sort", "sort", [null, "Alphabetical", "First Owned"], "Pokédex Number"); };
 var getTwitchVideos = getTwitchVideos || function () { };
 function twitchButton() {
     var button = document.createElement("li");

--- a/pokedex.html
+++ b/pokedex.html
@@ -136,6 +136,7 @@
 			drawControls([
 				pokedexGenerationsMenu(),
 				pokedexRegionsMenu(),
+				pokedexSortMenu(),
 				qsOptionsMenu("fa-sliders","Options",{
 					"justmon": "Just List Pokémon",
 					"owned": "Only Show Owned Pokémon",


### PR DESCRIPTION
In short, I wanted to see the Pokédex sorted by which run each Pokémon was first caught in. The "First Caught" sort isn't quite that, but it is close enough for my purposes and is more useful in other ways.

The alpha sort was because I feel like other sorts should be possible and needed a second example of sorting, even if I'm not sure what a second useful sort would be.
